### PR TITLE
Add Dockerfile for baked-pdf for easier installation

### DIFF
--- a/.dockerfiles/docker-entrypoint.sh
+++ b/.dockerfiles/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# This is run every time the docker container starts up.
+
+set -e
+
+if [ ! -d /src/node_modules ]
+then
+    cd /src/typeset/
+    # We need to do this when the container starts up instead of at build time
+    # because "npm install" adds files to /src/ which are wiped
+    # when we start the container because we mount baked-pdf
+    npm install
+    cd -
+fi
+
+exec "$@"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+##
+## Create an image that can be used to play with
+## baked-pdf commands.
+##
+## To create the image:
+##    docker build -t openstax/cnx-bakedpdf:latest .
+##
+## To start the container:
+##    docker run --mount type=bind,source=$(pwd),target=/src -it openstax/cnx-bakedpdf:latest /bin/bash
+## where the baked-pdf repo has been cloned into the
+## current working directory.
+##
+## To run the code:
+##    cd /src/typeset
+##    node start -i <input> -c <style> -o <output>
+## where <X> are filenames, e.g.:
+##    node start -i ../test-simple.xhtml -o output.html
+## See:
+##    https://github.com/openstax/baked-pdf
+## for details.
+##
+
+FROM ubuntu:latest as baseline
+WORKDIR /
+RUN apt-get update
+RUN apt-get -y install curl
+RUN apt-get -y install ed
+RUN apt-get -y install git
+RUN apt-get -y install vim
+RUN apt-get -y install gnupg
+RUN apt-get -y install make
+RUN apt-get -y install build-essential
+RUN apt-get -y install libx11-dev
+## from: https://github.com/GoogleChrome/puppeteer/issues/404
+RUN apt-get -y install libpangocairo-1.0-0 libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxi6 libxtst6 libnss3 libcups2 libxss1 libxrandr2 libgconf2-4 libasound2 libatk1.0-0 libgtk-3-0
+
+FROM baseline as install-node
+WORKDIR /
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN apt-get install -y nodejs
+
+COPY . /src
+WORKDIR /src/
+RUN npm install
+COPY ./.dockerfiles/docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]


### PR DESCRIPTION
There's example usage at the top of Dockerfile:

```
To create the image:
   docker build -t openstax/cnx-bakedpdf:latest .

To start the container:
   docker run --mount type=bind,source=$(pwd),target=/src -it openstax/cnx-bakedpdf:latest /bin/bash
where the baked-pdf repo has been cloned into the
current working directory.

To run the code:
   cd /src/typeset
   node start -i <input> -c <style> -o <output>
where <X> are filenames, e.g.:
   node start -i ../test-simple.xhtml -o output.html
```